### PR TITLE
Revert manifest permission

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,8 +58,7 @@
       }
     ],
     "host_permissions": [
-      "https://twitter.com/*",
-      "https://x.com/*"
+      "<all_urls>"
     ]
   }
 }


### PR DESCRIPTION
This reverts commit 6989c1e04047d06ec1870067691ccd373b1b969d.

(I need a pull request template...)

FlyFree needs permissions at `background.js` fetch image...